### PR TITLE
Update Rust compiler version to match Ruff's MSRV

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -31,7 +31,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -31,7 +31,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -31,7 +31,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -31,7 +31,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -31,7 +31,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -27,7 +27,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -29,7 +29,7 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -17,6 +17,6 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -17,6 +17,6 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -17,6 +17,6 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -17,6 +17,6 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -17,6 +17,6 @@ python:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.76'
+- '1.80'
 target_platform:
 - win-64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
 rust_compiler_version:
-  - "1.76"
+  - "1.80"


### PR DESCRIPTION
This PR fixes the build failure in https://github.com/conda-forge/ruff-feedstock/pull/228 by updating the Rust compiler version to the MSRV of Ruff.

Related to https://github.com/astral-sh/ruff/pull/13826