### PR TITLE
Bump Rust toolchain to 1.93

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,6 +17,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.92'
+- '1.93'
 target_platform:
 - linux-64

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -17,6 +17,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.92'
+- '1.93'
 target_platform:
 - linux-aarch64

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -21,6 +21,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.92'
+- '1.93'
 target_platform:
 - osx-64

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -21,6 +21,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.92'
+- '1.93'
 target_platform:
 - osx-arm64

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -9,6 +9,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.92'
+- '1.93'
 target_platform:
 - win-64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
 rust_compiler_version:
-  - "1.92"
+  - "1.93"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,7 +15,7 @@ source:
   sha256: f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33
 
 build:
-  number: 0
+  number: 1
 
   # we only build 1 package for each target platform
   python:


### PR DESCRIPTION
I think this will help with https://github.com/conda-forge/ruff-feedstock/pull/338 but it's a bit overdue after https://github.com/astral-sh/ruff/pull/24677 anyway.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
