### PR TITLE
Bump Rust toolchain to 1.94

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,6 +17,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.93'
+- '1.94'
 target_platform:
 - linux-64

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -17,6 +17,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.93'
+- '1.94'
 target_platform:
 - linux-aarch64

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -21,6 +21,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.93'
+- '1.94'
 target_platform:
 - osx-64

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -21,6 +21,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.93'
+- '1.94'
 target_platform:
 - osx-arm64

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -9,6 +9,6 @@ python_min:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.93'
+- '1.94'
 target_platform:
 - win-64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
 rust_compiler_version:
-  - "1.93"
+  - "1.94"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f
 
 build:
-  number: 0
+  number: 1
 
   # we only build 1 package for each target platform
   python:


### PR DESCRIPTION
## Summary

- Bump `rust_compiler_version` from `1.93` to `1.94` to follow Ruff's updated MSRV in astral-sh/ruff#25443.
- Increment the build number for the unchanged Ruff `0.15.14` package.
- Update the rendered CI variant files to match the Rust compiler pin.

## Checklist

* [x] Used a personal fork of the feedstock to propose changes.
* [x] Bumped the build number because the package version is unchanged.
* [ ] Re-rendered with the latest `conda-smithy`.
